### PR TITLE
Add 2-face extraction and adjacent Lagrangian detection

### DIFF
--- a/packages/rust_viterbo/ffi/src/lib.rs
+++ b/packages/rust_viterbo/ffi/src/lib.rs
@@ -54,7 +54,7 @@ fn tube_capacity_hrep(
     let polytope = PolytopeHRep::new(normals_vec, heights);
     polytope.validate(unit_tol).map_err(map_validation_error)?;
 
-    let lagrangian_detection = detect_near_lagrangian(&polytope.normals, eps_lagr);
+    let lagrangian_detection = detect_near_lagrangian(&polytope, eps_lagr, 1e-9, 1e-7);
     let (polytope, perturbation) = if lagrangian_detection.detected {
         let outcome = perturb_polytope_normals(&polytope, seed, eps_perturb);
         (outcome.polytope, Some(outcome.metadata))


### PR DESCRIPTION
## Summary
- add 2-face enumeration from H-rep in R^4 with deduped (optionally cyclic) vertex ordering
- tighten Lagrangian detection to adjacent facet pairs only

## Task(s)
- Refs #28 (MVP slice: 2-face extraction + adjacent Lagrangian checks)

## Changes
- implement `TwoFace` + `PolytopeHRep::two_faces` with 4x4 solves, feasibility checks, dedup, and planar ordering in `packages/rust_viterbo/geom/src/lib.rs`
- update `detect_near_lagrangian` to use adjacency via `two_faces` in `packages/rust_viterbo/geom/src/lib.rs`
- adjust FFI callsite to new detection signature in `packages/rust_viterbo/ffi/src/lib.rs`
- add deterministic tesseract tests for face enumeration + Lagrangian adjacency in `packages/rust_viterbo/geom/src/lib.rs`

## Testing and Quality Assurance
- `export CARGO_TARGET_DIR="/workspaces/worktrees/shared/target-$(basename $(pwd))" && cargo fmt --check --all --manifest-path packages/rust_viterbo/Cargo.toml`
- `export CARGO_TARGET_DIR="/workspaces/worktrees/shared/target-$(basename $(pwd))" && cargo clippy --workspace --all-targets --manifest-path packages/rust_viterbo/Cargo.toml -- -D warnings`
- `export CARGO_TARGET_DIR="/workspaces/worktrees/shared/target-$(basename $(pwd))" && cargo test --workspace --manifest-path packages/rust_viterbo/Cargo.toml`

## Risks / notes
- face enumeration uses tolerance-based feasibility/dedup; eps values may need tuning for ill-conditioned inputs

## Remaining work
- Follow-ups:
  - transition maps (`phi`, `A_inc`) for 2-faces
  - directed crossing logic / directionality for 2-face adjacency

---
Written-by: codex agent running in worktree /workspaces/worktrees/agent-2faces-mvp-a
