### PR TITLE
Add 2-face enumeration for H-rep polytopes

### DIFF
--- a/packages/rust_viterbo/ffi/src/lib.rs
+++ b/packages/rust_viterbo/ffi/src/lib.rs
@@ -54,7 +54,7 @@ fn tube_capacity_hrep(
     let polytope = PolytopeHRep::new(normals_vec, heights);
     polytope.validate(unit_tol).map_err(map_validation_error)?;
 
-    let lagrangian_detection = detect_near_lagrangian(&polytope.normals, eps_lagr);
+    let lagrangian_detection = detect_near_lagrangian(&polytope, eps_lagr, 1e-9, 1e-9);
     let (polytope, perturbation) = if lagrangian_detection.detected {
         let outcome = perturb_polytope_normals(&polytope, seed, eps_perturb);
         (outcome.polytope, Some(outcome.metadata))


### PR DESCRIPTION
## Summary
- implement 2-face enumeration for H-rep polytopes in R^4 and use it for adjacency-only Lagrangian detection.

## Task(s)
- MVP slice of issue #28 (polytope 2-faces). Refs #28.

## Changes
- add `TwoFace` and `PolytopeHRep::two_faces` with vertex enumeration + cyclic ordering in `packages/rust_viterbo/geom/src/lib.rs`.
- restrict `detect_near_lagrangian` to adjacent facet pairs derived from `two_faces` in `packages/rust_viterbo/geom/src/lib.rs`.
- update FFI callsite to new detection signature in `packages/rust_viterbo/ffi/src/lib.rs`.
- add deterministic cube (tesseract) tests for face enumeration and Lagrangian counts in `packages/rust_viterbo/geom/src/lib.rs`.

## Testing and Quality Assurance
- `CARGO_TARGET_DIR="/workspaces/worktrees/shared/target-$(basename $(pwd))" cargo fmt --all --manifest-path packages/rust_viterbo/Cargo.toml`
- `CARGO_TARGET_DIR="/workspaces/worktrees/shared/target-$(basename $(pwd))" cargo clippy --workspace --all-targets --manifest-path packages/rust_viterbo/Cargo.toml -- -D warnings`
- `CARGO_TARGET_DIR="/workspaces/worktrees/shared/target-$(basename $(pwd))" cargo test --workspace --manifest-path packages/rust_viterbo/Cargo.toml`

## Risks / notes
- `detect_near_lagrangian` now depends on face enumeration; for FFI I used fixed `eps_feas/eps_dedup = 1e-9` until a public parameter is introduced.
- Vertex ordering uses a simple Gram–Schmidt basis; if normals become nearly dependent it falls back to unsorted order.

## Remaining work
- Follow-ups for #28:
  1) directionality/directed crossing logic for adjacent faces,
  2) transition map (`phi`) + `A_inc` construction.

---
Written-by: codex agent running in worktree /workspaces/worktrees/agent-2faces-mvp-b
