### PR TITLE
Add 2-face enumeration for H-rep polytopes

### DIFF
--- a/packages/rust_viterbo/ffi/src/lib.rs
+++ b/packages/rust_viterbo/ffi/src/lib.rs
@@ -54,7 +54,9 @@ fn tube_capacity_hrep(
     let polytope = PolytopeHRep::new(normals_vec, heights);
     polytope.validate(unit_tol).map_err(map_validation_error)?;
 
-    let lagrangian_detection = detect_near_lagrangian(&polytope.normals, eps_lagr);
+    let eps_feas = 1e-9;
+    let eps_dedup = 1e-8;
+    let lagrangian_detection = detect_near_lagrangian(&polytope, eps_lagr, eps_feas, eps_dedup);
     let (polytope, perturbation) = if lagrangian_detection.detected {
         let outcome = perturb_polytope_normals(&polytope, seed, eps_perturb);
         (outcome.polytope, Some(outcome.metadata))


### PR DESCRIPTION
## Summary
- enumerate non-empty 2-faces in R^4 H-rep polytopes with optional cyclic vertex ordering
- restrict Lagrangian detection to adjacent facet pairs using 2-face extraction
- add deterministic tesseract tests for 2-face counts and Lagrangian face detection

## Assumptions
- use fixed epsilons for adjacency in the FFI path (eps_feas=1e-9, eps_dedup=1e-8) until exposed in the API

## Testing
- cargo fmt --check --all --manifest-path packages/rust_viterbo/Cargo.toml
- cargo clippy --workspace --all-targets --manifest-path packages/rust_viterbo/Cargo.toml -- -D warnings
- cargo test --workspace --manifest-path packages/rust_viterbo/Cargo.toml

Refs #28

## Follow-ups
- add transition maps (phi, A_inc) on adjacent faces
- add directed crossing logic/directionality in tube search