### PR TITLE
Refactor billiard solver: improve p-position tracking and add HK2017 comparison tests

### DIFF
--- a/packages/rust_viterbo/Cargo.lock
+++ b/packages/rust_viterbo/Cargo.lock
@@ -22,7 +22,8 @@ name = "billiard"
 version = "0.1.0"
 dependencies = [
  "approx",
- "itertools 0.13.0",
+ "hk2017",
+ "itertools",
  "nalgebra",
  "thiserror",
 ]
@@ -56,7 +57,7 @@ name = "hk2017"
 version = "0.1.0"
 dependencies = [
  "approx",
- "itertools 0.14.0",
+ "itertools",
  "nalgebra",
  "thiserror",
 ]
@@ -68,15 +69,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
 ]
 
 [[package]]

--- a/packages/rust_viterbo/billiard/Cargo.toml
+++ b/packages/rust_viterbo/billiard/Cargo.toml
@@ -8,8 +8,9 @@ description = "Billiard algorithm for EHZ capacity of Lagrangian product polytop
 
 [dependencies]
 nalgebra = "0.33"
-itertools = "0.13"
+itertools = "0.14"
 thiserror = "2"
 
 [dev-dependencies]
 approx = "0.5"
+hk2017 = { path = "../hk2017" }

--- a/packages/rust_viterbo/billiard/src/types.rs
+++ b/packages/rust_viterbo/billiard/src/types.rs
@@ -159,28 +159,35 @@ pub struct EdgeCombination {
 }
 
 /// A k-bounce billiard trajectory.
+///
+/// For a k-bounce trajectory, the 4D path alternates between:
+/// - q-motion (when on a p-facet): q moves while p stays fixed
+/// - p-motion (when on a q-facet): p moves while q stays fixed
+///
+/// The `p_positions[i]` gives the p-position during the q-motion from q_i → q_{i+1 mod k}.
 #[derive(Debug, Clone)]
 pub struct BilliardTrajectory {
     /// Number of bounces.
     pub num_bounces: usize,
     /// Bounce points in q-space (on ∂K_q).
     pub q_positions: Vec<Vector2<f64>>,
-    /// Corresponding p-positions (on ∂K_p).
+    /// The p-position during each q-motion segment.
+    /// `p_positions[i]` is where p is during q_i → q_{i+1 mod k}.
     pub p_positions: Vec<Vector2<f64>>,
-    /// Edge parameters t ∈ [0,1] for q-positions.
+    /// Edge parameters t ∈ [0,1] for q-positions on their respective edges.
     pub q_params: Vec<f64>,
-    /// Edge parameters t ∈ [0,1] for p-positions.
-    pub p_params: Vec<f64>,
-    /// Edge indices in K_q.
+    /// Edge indices in K_q where each bounce point lies.
     pub q_edges: Vec<usize>,
-    /// Edge indices in K_p.
-    pub p_edges: Vec<usize>,
     /// Total action (= T°-length = capacity).
     pub action: f64,
 }
 
 impl BilliardTrajectory {
-    /// Convert to 4D breakpoints.
+    /// Convert to 4D breakpoints at the start of each q-motion segment.
+    ///
+    /// Returns points `(q_i, p_i)` where `p_i` is the p-position during the q-motion
+    /// from `q_i` to `q_{i+1 mod k}`. These are the positions where the trajectory
+    /// transitions from p-motion to q-motion.
     pub fn to_4d_breakpoints(&self) -> Vec<Vector4<f64>> {
         self.q_positions
             .iter()


### PR DESCRIPTION
## Summary
This PR refactors the billiard trajectory solver to properly track p-positions as 2D vectors instead of edge parameters, adds comprehensive comparison tests with the HK2017 algorithm, and improves code documentation and clarity.

## Task(s)
- Improve p-position representation in billiard trajectories for better clarity and correctness
- Add integration tests comparing billiard and HK2017 algorithms on common test cases
- Upgrade itertools dependency to 0.14 for consistency across packages
- Enhance documentation of trajectory structure and solver functions

## Changes

### High-level changes:
1. **P-position tracking refactor** (`billiard/src/solve.rs`, `billiard/src/types.rs`)
   - Changed `SolveResult.p_params: Vec<f64>` to `p_positions: Vec<Vector2<f64>>` to store actual p-positions instead of edge parameters
   - Updated `BilliardTrajectory` to remove `p_params` and `p_edges` fields, keeping only `p_positions`
   - Simplified trajectory building by directly using computed p-positions from validation functions

2. **Algorithm validation improvements** (`billiard/src/solve.rs`)
   - Modified `validate_3bounce_orbit()` to return `Option<(Vector2, Vector2, Vector2)>` with actual p-positions instead of boolean
   - Simplified `validate_2bounce_orbit()` to return p-positions
   - Replaced verbose match statements with `?` operator for cleaner error handling
   - Simplified `solve_2bounce()` and `solve_3bounce()` to use returned p-positions directly

3. **HK2017 comparison tests** (`billiard/src/algorithm.rs`)
   - Added new `hk2017_comparison_tests` module with 4 test cases:
     - `test_tesseract_both_algorithms()`: Square × Square
     - `test_rectangle_product_both_algorithms()`: Rectangle × Square
     - `test_square_product_scaled()`: Scaled tesseract
     - `test_different_squares()`: Small × Large squares
   - Helper function `compare_algorithms()` runs both solvers and verifies results match within tolerance

4. **Dependency updates** (`Cargo.lock`, `billiard/Cargo.toml`)
   - Upgraded itertools from 0.13 to 0.14 in billiard package
   - Unified itertools version across packages (removed 0.13.0 entry from lock file)
   - Added hk2017 as dev-dependency for billiard tests

5. **Documentation improvements** (`billiard/src/solve.rs`, `billiard/src/types.rs`)
   - Enhanced docstrings for `find_p_position_for_q_motion()` with clearer parameter descriptions
   - Added detailed comments explaining trajectory structure and p-position semantics
   - Clarified `unit_cube_vertices()` function purpose and closure constraint explanation
   - Improved `BilliardTrajectory` and `to_4d_breakpoints()` documentation

### Low-level changes:
- `billiard/src/solve.rs`: Lines 38-44 (docstring), 143-149 (SolveResult struct), 266-287 (solve_2bounce logic), 306-333 (validate_3bounce_orbit signature and implementation), 372-443 (solve_3bounce refactoring), 445-461 (unit_cube_vertices function), 463-485 (build_trajectory simplification)
- `billiard/src/types.rs`: Lines 162-183 (BilliardTrajectory struct and documentation)
- `billiard/src/algorithm.rs`: Lines 145-225 (new hk2017_comparison_tests module)
- `billiard/Cargo.toml`: Lines 11, 15 (dependency updates)
- `Cargo.lock`: Lines 25-26, 59 (version consolidation)

## Testing and Quality Assurance

### Tests added:
- 4 new integration tests in