### PR TITLE
Consolidate SessionStart hooks to prevent duplicate UI messages

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# SessionStart hook wrapper - runs appropriate scripts based on source
+# Combines web-env-setup.sh and hello.sh into one hook to avoid duplicate UI messages
+
+set -e
+
+# Read hook input from stdin (SessionStart provides JSON with source field)
+hook_input=$(cat)
+source=$(echo "$hook_input" | jq -r '.source // "startup"')
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# web-env-setup: only on startup (gh persists in VM)
+if [ "$source" = "startup" ]; then
+    echo "$hook_input" | "$SCRIPT_DIR/web-env-setup.sh" || true
+fi
+
+# hello.sh: on startup/compact/clear (skip resume - agent still has context)
+if [ "$source" != "resume" ]; then
+    echo "$hook_input" | "$PROJECT_DIR/scripts/hello.sh" || true
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,11 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -lc \"$CLAUDE_PROJECT_DIR/.claude/hooks/web-env-setup.sh\""
-          },
-          {
-            "type": "command",
-            "command": "bash -lc scripts/hello.sh"
+            "command": "bash -lc \"$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh\""
           }
         ]
       }


### PR DESCRIPTION
## Summary
Consolidates two separate SessionStart hooks (`web-env-setup.sh` and `hello.sh`) into a single unified hook wrapper that intelligently runs scripts based on the session source, eliminating duplicate UI messages.

## Task(s)
- Prevent duplicate UI messages from multiple SessionStart hooks
- Maintain existing functionality while improving hook organization

## Changes
- **New file**: `.claude/hooks/session-start.sh`
  - Unified hook wrapper that reads JSON input from stdin
  - Extracts `source` field to determine session type (startup/resume/compact/clear)
  - Conditionally runs `web-env-setup.sh` only on startup (since GitHub Codespaces persists environment in VM)
  - Conditionally runs `scripts/hello.sh` on startup/compact/clear (skips resume to preserve agent context)
  - Includes error handling with `|| true` to prevent hook failures from blocking session start

- **Modified**: `.claude/settings.json`
  - Removed two separate hook commands (lines 8-11)
  - Replaced with single hook command pointing to new `session-start.sh` wrapper (line 8)

## Testing and Quality Assurance
- Hook logic verified through code inspection:
  - `source` field extraction from JSON input
  - Conditional execution paths for different session sources
  - Error handling prevents hook failures from blocking sessions
- Backward compatibility maintained: all original scripts still execute in appropriate contexts
- No new test automation added (hooks are integration-level and tested through normal session workflows)

## Risks / notes
- Hook behavior now depends on `source` field being present in SessionStart JSON input. If this field is missing or malformed, it defaults to "startup" (safe default)
- The `|| true` error handling suppresses failures silently—if either script fails, the session continues but the failure is not logged
- Requires `jq` to be available in the environment for JSON parsing

## Remaining work
- None identified. The consolidation is complete and maintains all existing functionality while solving the duplicate message issue.

https://claude.ai/code/session_01X83uxq3dvTFGo6USD2XwmU