### PR TITLE
FFI cleanup: remove archived stubs, fix type stubs and docs

### DIFF
--- a/.claude/skills/ffi-pyo3-maturin/SKILL.md
+++ b/.claude/skills/ffi-pyo3-maturin/SKILL.md
@@ -1,21 +1,38 @@
 ---
 name: ffi-pyo3-maturin
-description: Build or modify the Rust↔Python FFI using PyO3+maturin. Use for binding builds, smoke tests, and boundary validation workflow.
+description: Build or modify the Rust-Python FFI using PyO3+maturin. Use for binding builds, smoke tests, and boundary validation workflow.
 ---
 
 # PyO3 + maturin FFI Workflow
 
 ## Build
 
-- `cd packages/python_viterbo && uv run maturin develop --manifest-path ../rust_viterbo/Cargo.toml`
+```bash
+cd packages/python_viterbo && uv run maturin develop --manifest-path ../rust_viterbo/ffi/Cargo.toml
+```
 
 ## Test
 
-- `cd packages/python_viterbo && uv run pytest -q tests/smoke`
+```bash
+cd packages/python_viterbo && uv run pytest tests/test_ffi_capacity_hrep.py -v
+```
 
-## Contract and expectations
+## API Overview
 
-- See: `packages/rust_viterbo/docs/ffi-contract.md`
-- Keep wrappers thin and convert types near the boundary.
-- Validate inputs at the boundary, return structured errors.
-- Avoid breaking Python-facing APIs without coordination.
+The FFI exposes:
+
+- `hk2017_capacity_hrep(normals, heights, use_graph_pruning=False) -> Hk2017Result`: Compute EHZ capacity using the HK2017 combinatorial formula
+- `symplectic_form_4d(a, b) -> float`: Compute the standard symplectic form in R^4
+
+## Design Principles
+
+1. **Keep wrappers thin**: Convert types at the boundary, delegate to library crates
+2. **Validate at boundary**: Check inputs in FFI code, return structured errors
+3. **Expose only working code**: No stubs or archived placeholders - if it's not implemented, don't expose it
+4. **Match stubs to implementation**: `rust_viterbo_ffi.pyi` must accurately reflect the actual API
+
+## Files
+
+- Rust FFI: `packages/rust_viterbo/ffi/src/lib.rs`
+- Python stubs: `packages/python_viterbo/src/rust_viterbo_ffi.pyi`
+- Tests: `packages/python_viterbo/tests/test_ffi_capacity_hrep.py`

--- a/TODO.md
+++ b/TODO.md
@@ -21,7 +21,7 @@ See `.claude/skills/project-management/SKILL.md` for conventions.
 - [ ] Benchmarks/profiling harness for algorithm trusted v1 (#33)
 - [-] Download HK thesis: verify sys ≤ 3/4 for simplices claim, extract known polytope values for validation — blocked on CC web (no CONNECT tunneling for JS pages); retry in local devcontainer
 - [ ] Cross-algorithm validation: billiard vs hk2017 on Lagrangian products, continuity-based billiard↔tube comparison; thesis section + code fixtures
-- [-] FFI ergonomics: vector types + Python stubs (#37) — deferred, not blocking core work
+- [x] FFI cleanup: removed archived stubs, legacy aliases, fixed type stubs (#37) (2026-01-27)
 - [-] HK2017 QCQP solver: remove interior-point assumption — blocked on higher-prio items; big feature but worth background attempt
 
 ## Thesis Writing

--- a/packages/python_viterbo/src/rust_viterbo_ffi.pyi
+++ b/packages/python_viterbo/src/rust_viterbo_ffi.pyi
@@ -1,63 +1,47 @@
+"""Type stubs for rust_viterbo_ffi.
+
+This module provides Python bindings to Rust implementations of EHZ capacity
+algorithms for convex polytopes.
+"""
+
 from __future__ import annotations
 
-from typing import Sequence, TypedDict
+from typing import Sequence
 
 Vector4 = tuple[float, float, float, float]
-
-class WitnessOrbit(TypedDict):
-    breakpoints: list[Vector4]
-    facet_sequence: list[int]
-    segment_times: list[float]
-
-class Diagnostics(TypedDict):
-    nodes_explored: int
-    nodes_pruned_empty: int
-    nodes_pruned_action: int
-    nodes_pruned_rotation: int
-    best_action_found: float
-    lagrangian: str | None
-    perturbation: str
-
-class CapacityResult(TypedDict):
-    capacity: float
-    diagnostics: Diagnostics
-    witness: WitnessOrbit | None
-
-def symplectic_form_4d(a: Vector4, b: Vector4) -> float: ...
-def tube_capacity_hrep(
-    normals: Sequence[Vector4], heights: Sequence[float], *, unit_tol: float = ...
-) -> CapacityResult:
-    """Compute EHZ capacity using the Tube (CH2021) algorithm."""
-    ...
-
-def billiard_capacity_hrep(
-    normals: Sequence[Vector4], heights: Sequence[float], *, unit_tol: float = ...
-) -> CapacityResult:
-    """Compute EHZ capacity using the Minkowski billiard algorithm.
-
-    Only works for Lagrangian products K = K₁ × K₂.
-    """
-    ...
-
-def hk2019_capacity_hrep(
-    normals: Sequence[Vector4], heights: Sequence[float], *, unit_tol: float = ...
-) -> float:
-    """LEGACY: Compute EHZ capacity using the HK2017 algorithm.
-
-    This is an alias for hk2017_capacity_hrep for backwards compatibility.
-    Returns just the capacity value (not the full result object).
-    """
-    ...
 
 class Hk2017Result:
     """Result of HK2017 capacity computation."""
 
-    capacity: float
-    q_max: float
-    optimal_permutation: list[int]
-    optimal_beta: list[float]
-    permutations_evaluated: int
-    permutations_rejected: int
+    @property
+    def capacity(self) -> float:
+        """The computed EHZ capacity."""
+        ...
+
+    @property
+    def q_max(self) -> float:
+        """The maximum Q value achieved (capacity = 4/q_max)."""
+        ...
+
+    @property
+    def optimal_permutation(self) -> list[int]:
+        """Indices of facets in the optimal cyclic ordering."""
+        ...
+
+    @property
+    def optimal_beta(self) -> list[float]:
+        """The beta values (time spent on each facet) at the optimum."""
+        ...
+
+    @property
+    def permutations_evaluated(self) -> int:
+        """Number of permutations evaluated."""
+        ...
+
+    @property
+    def permutations_rejected(self) -> int:
+        """Number of permutations rejected by pruning criteria."""
+        ...
 
 def hk2017_capacity_hrep(
     normals: Sequence[Vector4],
@@ -65,6 +49,9 @@ def hk2017_capacity_hrep(
     use_graph_pruning: bool = False,
 ) -> Hk2017Result:
     """Compute EHZ capacity using the HK2017 combinatorial formula.
+
+    Implements the algorithm from Haim-Kislev's paper "On the Symplectic Size
+    of Convex Polytopes" (arXiv:1712.03494, published GAFA 2019).
 
     Args:
         normals: Unit outward normal vectors for each facet.
@@ -74,5 +61,31 @@ def hk2017_capacity_hrep(
 
     Returns:
         Hk2017Result with capacity, optimal permutation, and statistics.
+
+    Raises:
+        ValueError: If the polytope is invalid (non-unit normals, non-positive
+            heights, mismatched lengths, etc.).
+
+    Warning:
+        This implementation assumes the global maximum of Q occurs at an
+        interior point. If the true maximum is on the boundary, the result
+        may be incorrect.
+    """
+    ...
+
+def symplectic_form_4d(a: Vector4, b: Vector4) -> float:
+    """Compute the symplectic form ω(a, b) in R⁴.
+
+    The standard symplectic form is:
+        ω(x, y) = x₁y₃ + x₂y₄ - x₃y₁ - x₄y₂
+
+    where x = (q₁, q₂, p₁, p₂) and y = (q₁', q₂', p₁', p₂').
+
+    Args:
+        a: First vector [q₁, q₂, p₁, p₂].
+        b: Second vector [q₁', q₂', p₁', p₂'].
+
+    Returns:
+        The symplectic form value ω(a, b).
     """
     ...


### PR DESCRIPTION
## Summary
Remove archived algorithm stubs (`tube_capacity_hrep`, `billiard_capacity_hrep`, `hk2019_capacity_hrep`) from the FFI, fix Python type stubs to accurately reflect the actual API, and improve documentation across Rust and Python layers.

## Task(s)
Closes #37: FFI cleanup - removed archived stubs, legacy aliases, fixed type stubs

## Changes

### High-level
- **Removed archived/legacy functions**: Deleted `tube_capacity_hrep`, `billiard_capacity_hrep`, and `hk2019_capacity_hrep` from both Rust FFI and Python stubs. These were archived implementations that should not be exposed.
- **Fixed Python type stubs**: Converted `Hk2017Result` from `TypedDict` to a proper `@dataclass`-like stub with `@property` decorators matching the actual Rust implementation. Removed stubs for non-existent functions.
- **Improved documentation**: Added comprehensive docstrings with examples, parameter descriptions, and warnings. Updated skill documentation with current API and design principles.
- **Enhanced test coverage**: Reorganized tests, added fixtures, improved error handling tests, and removed legacy API tests.

### Low-level changes

**Rust FFI** (`packages/rust_viterbo/ffi/src/lib.rs`):
- Removed `tube_capacity_hrep`, `billiard_capacity_hrep`, `hk2019_capacity_hrep` functions (lines 185-227 in original)
- Renamed `Hk2017ResultPy` to `Hk2017Result` for clarity (line 99)
- Added detailed field documentation with `///` comments (lines 101-126)
- Improved `__repr__` formatting with precision specifiers (line 131)
- Moved `symplectic_form_4d` after `Hk2017Result` for logical grouping (lines 139-157)
- Enhanced module-level documentation with Python usage example (lines 8-24)
- Simplified `#[pymodule]` registration to only expose working functions (lines 187-192)

**Python type stubs** (`packages/python_viterbo/src/rust_viterbo_ffi.pyi`):
- Removed `WitnessOrbit`, `Diagnostics`, `CapacityResult` TypedDicts (no longer used)
- Removed stubs for `tube_capacity_hrep`, `billiard_capacity_hrep`, `hk2019_capacity_hrep`
- Converted `Hk2017Result` to property-based class with `@property` decorators (lines 13-48)
- Added comprehensive docstrings with algorithm reference, parameter descriptions, and error documentation (lines 50-72)
- Moved `symplectic_form_4d` to end with full documentation (lines 74-88)
- Added module-level docstring (lines 1-4)

**Tests** (`packages/python_viterbo/tests/test_ffi_capacity_hrep.py`):
- Added `simplex_hrep()` fixture for reusable test data (lines 48-60)
- Reorganized test sections with clearer headers (lines 62-67)
- Enhanced `test_hk2017_simplex_runs()` to verify result properties (lines 77-84)
- Added `test_hk2017_result_repr()` to validate string representation (lines 87-94)
- Removed `test_hk2019_legacy_api()`, `test_billiard_archived()`, `test_tube_archived()` (no longer applicable)
- Reorganized symplectic form tests with better names and documentation (lines 104-127)
- Added `test_hk2017_invalid_mismatched_lengths()` for error handling (lines 133-139)

**Documentation** (`.claude/skills/ffi-pyo3-maturin/SKILL.md`):
- Updated build command to use correct FFI Cargo.toml path (line 11)
- Changed test command to specific test file with verbose output (line

https://claude.ai/code/session_011jRntz34supZuFvKsHu7JJ