### PR TITLE
Fix uv binary path in Docker build commands

### DIFF
--- a/.devcontainer/codespace/Dockerfile
+++ b/.devcontainer/codespace/Dockerfile
@@ -72,7 +72,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
 ENV UV_INSTALL_DIR=/usr/local
 ENV UV_VERSION=0.5.14
 RUN curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | sh \
-    && uv --version
+    && /usr/local/bin/uv --version
 
 # Switch to dev user for language toolchains.
 USER vscode

--- a/.devcontainer/local/Dockerfile
+++ b/.devcontainer/local/Dockerfile
@@ -88,7 +88,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
 ENV UV_INSTALL_DIR=/usr/local
 ENV UV_VERSION=0.5.14
 RUN curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | sh \
-    && uv --version
+    && /usr/local/bin/uv --version
 
 # Switch to dev user for language toolchains.
 # Toolchains live in the dev user's HOME so that cargo/elan behave normally.


### PR DESCRIPTION
## Summary
Use absolute path to `uv` binary in Docker build commands to ensure the correct executable is invoked after installation.

## Task(s)
- Fix potential PATH resolution issues with `uv` command in Docker containers

## Changes
- Updated `uv --version` commands to use absolute path `/usr/local/bin/uv --version`
  - `.devcontainer/codespace/Dockerfile` (line 75)
  - `.devcontainer/local/Dockerfile` (line 91)

## Testing and Quality Assurance
- The changes ensure that the `uv` binary installed to `/usr/local/bin/` (as specified by `UV_INSTALL_DIR=/usr/local`) is explicitly called rather than relying on PATH resolution
- This prevents potential issues where a different `uv` binary might be found in the PATH or where the PATH hasn't been updated yet in the Docker build context

## Risks / notes
- This is a defensive change that makes the build more explicit and reliable
- No functional behavior change expected; the same binary should be executed in both cases
- The absolute path approach is more robust in containerized environments where PATH state can be unpredictable during multi-stage builds

## Remaining work
- None identified

https://claude.ai/code/session_01NVZdDyBHUVGSy6mKnJc1E9