### PR TITLE
spec: algorithm_inventory experiment

### DIFF
--- a/packages/python_viterbo/src/viterbo/experiments/algorithm_inventory/SPEC.md
+++ b/packages/python_viterbo/src/viterbo/experiments/algorithm_inventory/SPEC.md
@@ -220,6 +220,23 @@ This validates the Mahler bound on available fixtures without requiring new geom
 - `viterbo_ffi` Python package (FFI bindings to Rust)
 - Rust workspace builds successfully (`scripts/test.sh` passes)
 
+## Files to Create/Modify
+
+### New Files
+- `src/viterbo/experiments/algorithm_inventory/stage_build.py` — generates JSON data
+- `src/viterbo/experiments/algorithm_inventory/stage_tabulate.py` — generates LaTeX tables
+- `src/viterbo/experiments/algorithm_inventory/FINDINGS.md` — documents results and escalation
+- `data/algorithm_inventory/*.json` — 4 data files (see Expected Outputs)
+- `packages/latex_viterbo/assets/algorithm_inventory/*.tex` — 4 table files
+
+### Existing Files (no modification expected)
+- `ffi/src/lib.rs` — FFI bindings already expose needed fields
+- `tube/src/fixtures.rs` — fixture definitions (read-only reference)
+
+## Open Questions
+
+None. All feasibility questions resolved during investigation.
+
 ## Out of Scope
 
 - Billiard algorithm (not implemented)


### PR DESCRIPTION
## Summary

Adds SPEC.md for the algorithm_inventory experiment (#124), which documents:
- Algorithms (HK2017 naive/graph, Tube, Billiard=absent)
- Fixtures (cross-polytope, tesseract, 4-simplex, 24-cell, etc.)
- Validation propositions (P1-P5) with FFI feasibility analysis
- Capacity comparison matrix

## Key Decisions

1. **Enumeration**: Hardcoded lists (algorithms/fixtures are few and stable)
2. **Validation**: FFI + Python logic (Rust computes, Python validates)
3. **P2 (Mahler)**: Use known dual pairs only (no 4D convex hull available)
4. **P5 (Orbit closure)**: Defer to existing Rust unit tests (breakpoints not exposed in FFI)

## Files

- `packages/python_viterbo/src/viterbo/experiments/algorithm_inventory/SPEC.md`

## Test plan

- [ ] Spec-review agent reviews SPEC.md
- [ ] Developer agent implements stage_build.py and stage_tabulate.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)