### PR TITLE
Configure memory limits and parallel build jobs for dev container

### DIFF
--- a/.devcontainer/local/devcontainer.json
+++ b/.devcontainer/local/devcontainer.json
@@ -26,11 +26,15 @@
   "workspaceFolder": "/workspaces/msc-viterbo",
   "updateRemoteUserUID": true,
   "features": {},
+  // Memory limit: 12GB hard cap, no swap. Protects host from runaway processes.
+  // Container survives OOM; only the offending process is killed.
+  "runArgs": ["--memory=12g", "--memory-swap=12g"],
   "postCreateCommand": "bash .devcontainer/scripts/post-create.sh",
   // Removed: CARGO_TARGET_DIR shared between worktrees. See git history to restore.
   "containerEnv": {
     "DEVCONTAINER_ENV": "local",
-    "HISTFILE": "/home/vscode/.bash_history_dir/.bash_history"
+    "HISTFILE": "/home/vscode/.bash_history_dir/.bash_history",
+    "CARGO_BUILD_JOBS": "4"
   },
   // Bind mounts: Jörn's specific host paths for cache persistence.
   "mounts": [


### PR DESCRIPTION
## Summary
Configure resource constraints and build optimization for the local development container to prevent runaway processes and improve build performance.

## Task(s)
- Protect the host system from resource exhaustion by runaway processes in the dev container
- Optimize Rust build performance by controlling parallel job allocation

## Changes
- **Memory limits** (`.devcontainer/local/devcontainer.json`, lines 29-30):
  - Added `--memory=12g` and `--memory-swap=12g` to `runArgs` to enforce a 12GB hard cap
  - Container will survive OOM conditions; only the offending process is killed
  - Protects the host from being overwhelmed by container processes
  
- **Build optimization** (`.devcontainer/local/devcontainer.json`, line 37):
  - Added `CARGO_BUILD_JOBS: "4"` environment variable to limit parallel Rust compilation jobs
  - Prevents excessive CPU and memory usage during builds
  - Works in conjunction with memory limits to ensure stable builds

## Testing and Quality Assurance
- Configuration changes are declarative and will be applied automatically when the dev container is rebuilt
- Memory limits can be verified by running memory-intensive operations within the container and observing that processes are killed rather than the host becoming unresponsive
- Build job limit can be verified by observing `cargo build` output or checking `ps` during compilation

## Risks / notes
- The 12GB memory limit is specific to the documented host configuration (Jörn's setup); other developers may need to adjust based on their available resources
- The `CARGO_BUILD_JOBS=4` setting assumes a multi-core system; may need tuning for different hardware
- These are soft constraints that improve stability but don't guarantee resource isolation

## Remaining work
- None identified. These are configuration improvements for the existing dev container setup.

https://claude.ai/code/session_01MXU23H3yBdG56njQc75pL4