### PR TITLE
Configure Git to run non-interactively in Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,12 @@
 {
+  "env": {
+    "GIT_TERMINAL_PROMPT": "0",
+    "GIT_SSH_COMMAND": "ssh -oBatchMode=yes",
+    "GIT_ASKPASS": "/bin/true",
+    "GCM_INTERACTIVE": "Never",
+    "GIT_PAGER": "cat",
+    "GIT_EDITOR": "true"
+  },
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## Summary
Add environment variable configuration to `.claude/settings.json` to ensure Git operations run in non-interactive mode, preventing prompts and hangs during automated workflows.

## Task(s)
- Enable Claude to execute Git commands reliably without user interaction
- Prevent credential prompts and terminal interactions that could block execution

## Changes
- Added `env` configuration section to `.claude/settings.json` with Git-specific environment variables
  - `.claude/settings.json` (lines 2-9): New `env` object containing:
    - `GIT_TERMINAL_PROMPT=0`: Disable terminal prompts
    - `GIT_SSH_COMMAND="ssh -oBatchMode=yes"`: Force SSH batch mode (no interactive auth)
    - `GIT_ASKPASS="/bin/true"`: Disable password prompts
    - `GCM_INTERACTIVE=Never`: Disable Git Credential Manager interactive mode
    - `GIT_PAGER=cat`: Use simple pager instead of interactive pager
    - `GIT_EDITOR=true`: Use no-op editor instead of interactive editor

## Testing and Quality Assurance
- Configuration follows Git and SSH best practices for non-interactive environments
- Environment variables are standard Git configuration options documented in Git documentation
- No automated tests required as this is configuration-only change

## Risks / notes
- These settings globally disable interactive Git features for Claude's execution context
- Users performing manual Git operations through Claude may not receive interactive prompts they might expect
- SSH key-based authentication should be pre-configured for Git operations to work without `GIT_ASKPASS`

## Remaining work
- None identified

https://claude.ai/code/session_01DjWNMh1MWRLtx5KxuwAiqi