### PR TITLE
chore: reorganize troubleshoot skill sections

### DIFF
--- a/.claude/skills/troubleshoot/SKILL.md
+++ b/.claude/skills/troubleshoot/SKILL.md
@@ -11,12 +11,30 @@ You diagnose bugs with unknown root causes, then implement fixes.
 
 $ARGUMENTS
 
-## Core Principles
+## Domain Knowledge
 
 1. **Generate multiple hypotheses before testing any** — List 3-5 plausible causes
 2. **Falsify, don't verify** — Look for evidence that DISPROVES hypotheses
 3. **Kill hypotheses quickly** — Prioritize fast, definitive tests
 4. **Document what you ruled out** — Prevents repeating dead ends
+
+## Invariants
+
+### Escalation Rules
+
+Stop and ask Jörn when:
+- All hypotheses falsified
+- Multiple hypotheses survive
+- Root cause found but fix is risky
+- Confidence is low
+
+### Anti-Patterns
+
+- First-hypothesis fixation
+- Confirmation bias
+- Premature implementation
+- Mixing observations and inferences
+- Losing provenance
 
 ## Workflow
 
@@ -65,19 +83,3 @@ gh pr create --title "fix: <description>" --body "..."
 ```
 
 Include: hypotheses tested, evidence, root cause, fix description.
-
-## Escalation Rules
-
-Stop and ask Jörn when:
-- All hypotheses falsified
-- Multiple hypotheses survive
-- Root cause found but fix is risky
-- Confidence is low
-
-## Anti-Patterns
-
-- First-hypothesis fixation
-- Confirmation bias
-- Premature implementation
-- Mixing observations and inferences
-- Losing provenance


### PR DESCRIPTION
## Summary

Reorganizes the troubleshoot skill (`/.claude/skills/troubleshoot/SKILL.md`) using standardized section types:

- `## Assignment` - $ARGUMENTS placeholder (kept as-is)
- `## Domain Knowledge` - renamed from "Core Principles"; contains general debugging methodology (not project-specific)
- `## Invariants` - combines Escalation Rules and Anti-Patterns as subsections
- `## Workflow` - the 7 phases (kept as-is)

All content preserved, just reorganized under clear category headers per the skill-conventions.

## Out of scope

Other skills also need similar reorganization (already tracked separately).

Generated with Claude Code